### PR TITLE
feat: add results link to experiments table

### DIFF
--- a/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui_new/templates/nimbus_experiments/table.html
@@ -121,7 +121,9 @@
           </td>
           <td>
             {% if experiment.show_results_url %}
-              <a href="{% url "nimbus-results" slug=experiment.slug %}">Results</a>
+              <a href="{% url "nimbus-results" slug=experiment.slug %}">View Results</a>
+            {% else %}
+              <a>View Results</a>
             {% endif %}
           </td>
         </tr>


### PR DESCRIPTION
Because

- it is impossible to tell if an experiment has results without clicking into it
- it can be useful to see a list of experiments with/without results
- it can be useful to navigate directly to the experiment's results

This commit

 - adds a results link to the experiments table if results exist

Fixes #10946

![image](https://github.com/user-attachments/assets/8a2f7180-20a3-4842-95f4-2ad5b697587a)
